### PR TITLE
improve error feedback

### DIFF
--- a/dist/actions/index.js
+++ b/dist/actions/index.js
@@ -28,7 +28,7 @@ exports.removeAutoWidth = removeAutoWidth;
 function render(pOptions) {
     return readFromStream_1.readFromStream(fileNameToStream_1.getInStream(pOptions.inputFrom))
         .then((pInput) => getAST(pInput, pOptions))
-        .then((pAST) => render_1.renderTheShizzle(removeAutoWidth(pAST, pOptions.outputType), pOptions));
+        .then((pAST) => render_1.renderWithChromeHeadless(removeAutoWidth(pAST, pOptions.outputType), pOptions));
 }
 function transpile(pOptions) {
     return readFromStream_1.readFromStream(fileNameToStream_1.getInStream(pOptions.inputFrom))

--- a/dist/actions/render.js
+++ b/dist/actions/render.js
@@ -25,7 +25,7 @@ function getPuppeteerLaunchOptions(pPuppeteerLaunchOptions) {
         headless: true,
     }, pPuppeteerLaunchOptions || {});
 }
-function renderTheShizzle(pAST, pOptions) {
+function renderWithChromeHeadless(pAST, pOptions) {
     return __awaiter(this, void 0, void 0, function* () {
         let browser = {};
         try {
@@ -62,9 +62,6 @@ function renderTheShizzle(pAST, pOptions) {
                 });
             }
         }
-        catch (pError) {
-            return pError;
-        }
         finally {
             if (Boolean(browser) && typeof browser.close === "function") {
                 browser.close();
@@ -72,7 +69,7 @@ function renderTheShizzle(pAST, pOptions) {
         }
     });
 }
-exports.renderTheShizzle = renderTheShizzle;
+exports.renderWithChromeHeadless = renderWithChromeHeadless;
 /*
     This file is part of mscgenjs-cli.
     mscgenjs-cli is free software: you can redistribute it and/or modify

--- a/dist/actions/render.js
+++ b/dist/actions/render.js
@@ -38,7 +38,7 @@ function renderTheShizzle(pAST, pOptions) {
             yield page.addScriptTag({
                 path: require.resolve("mscgenjs-inpage"),
             });
-            yield page.waitFor("mscgen#replaceme[data-renderedby='mscgen_js']", { timeout: 10000 });
+            yield page.waitFor("mscgen#replaceme[data-renderedby='mscgen_js']");
             if (pOptions.outputType === "svg") {
                 return yield page.evaluate(() => {
                     const lSVGElement = document.getElementById("mscgenjsreplaceme");

--- a/dist/actions/render.js
+++ b/dist/actions/render.js
@@ -40,6 +40,12 @@ function renderWithChromeHeadless(pAST, pOptions) {
             });
             yield page.waitFor("mscgen#replaceme[data-renderedby='mscgen_js']");
             if (pOptions.outputType === "svg") {
+                /* the istanbul ignore thing is so istanbul won't instrument code
+                   that is meant to be run in browser context. If it does,
+                   you'll get errors like 'Error: Evaluation failed: ReferenceError: cov_'
+                   - which is chrome (not node) telling us something is foobar
+                */
+                /* istanbul ignore next */
                 return yield page.evaluate(() => {
                     const lSVGElement = document.getElementById("mscgenjsreplaceme");
                     if (lSVGElement) {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,10 @@
     "typescript": "2.7.2"
   },
   "nyc": {
-    "lines": 85,
+    "statements": 95.95,
+    "branches": 95.77,
+    "functions": 90.74,
+    "lines": 95.91,
     "reporter": [
       "text-summary",
       "html"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "npm-check-updates": "ncu --upgrade",
     "npm-install": "npm install",
     "nsp": "nsp check --warn-only",
-    "test": "mocha --require ts-node/register --timeout 10000 --reporter dot --recursive test/*.ts test/**/*.ts",
+    "test": "mocha --require ts-node/register --timeout 10000 --recursive test/*.ts test/**/*.ts",
     "test:cover": "nyc --extension .ts --check-coverage npm test",
     "update-dependencies": "npm-run-all npm-check-updates npm-install lint:fix depcruise build test",
     "watch": "tsc --project src --watch"

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -3,7 +3,7 @@ import * as pify from "pify";
 import { INormalizedOptions, OutputType } from "../types";
 import { getInStream, getOutStream } from "./fileNameToStream";
 import { readFromStream } from "./readFromStream";
-import { renderTheShizzle } from "./render";
+import { renderWithChromeHeadless } from "./render";
 
 const translate = pify(translateMsc);
 
@@ -37,7 +37,7 @@ function render(pOptions: INormalizedOptions): Promise<any> {
     return readFromStream(getInStream(pOptions.inputFrom))
         .then((pInput) => getAST(pInput, pOptions))
         .then((pAST) =>
-            renderTheShizzle(
+            renderWithChromeHeadless(
                 removeAutoWidth(pAST, pOptions.outputType),
                 pOptions,
             ),

--- a/src/actions/render.ts
+++ b/src/actions/render.ts
@@ -45,7 +45,7 @@ export async function renderTheShizzle(pAST: any, pOptions: INormalizedOptions) 
             path: require.resolve("mscgenjs-inpage"),
         });
 
-        await page.waitFor("mscgen#replaceme[data-renderedby='mscgen_js']", {timeout: 10000});
+        await page.waitFor("mscgen#replaceme[data-renderedby='mscgen_js']");
 
         if (pOptions.outputType === "svg") {
             return await page.evaluate(() => {

--- a/src/actions/render.ts
+++ b/src/actions/render.ts
@@ -48,6 +48,12 @@ export async function renderWithChromeHeadless(pAST: any, pOptions: INormalizedO
         await page.waitFor("mscgen#replaceme[data-renderedby='mscgen_js']");
 
         if (pOptions.outputType === "svg") {
+            /* the istanbul ignore thing is so istanbul won't instrument code
+               that is meant to be run in browser context. If it does, 
+               you'll get errors like 'Error: Evaluation failed: ReferenceError: cov_'
+               - which is chrome (not node) telling us something is foobar
+            */
+            /* istanbul ignore next */
             return await page.evaluate(() => {
                 const lSVGElement = document.getElementById("mscgenjsreplaceme");
                 if (lSVGElement) {

--- a/src/actions/render.ts
+++ b/src/actions/render.ts
@@ -49,7 +49,7 @@ export async function renderWithChromeHeadless(pAST: any, pOptions: INormalizedO
 
         if (pOptions.outputType === "svg") {
             /* the istanbul ignore thing is so istanbul won't instrument code
-               that is meant to be run in browser context. If it does, 
+               that is meant to be run in browser context. If it does,
                you'll get errors like 'Error: Evaluation failed: ReferenceError: cov_'
                - which is chrome (not node) telling us something is foobar
             */

--- a/src/actions/render.ts
+++ b/src/actions/render.ts
@@ -23,7 +23,7 @@ function getPuppeteerLaunchOptions(pPuppeteerLaunchOptions: IPuppeteerOptions) {
     );
 }
 
-export async function renderTheShizzle(pAST: any, pOptions: INormalizedOptions) {
+export async function renderWithChromeHeadless(pAST: any, pOptions: INormalizedOptions) {
 
     let browser: puppeteer.Browser = {} as puppeteer.Browser;
 
@@ -68,8 +68,6 @@ export async function renderTheShizzle(pAST: any, pOptions: INormalizedOptions) 
                 type: pOptions.outputType as any,
             });
         }
-    } catch (pError) {
-        return pError;
     } finally {
         if (Boolean(browser) && typeof browser.close === "function") {
             browser.close();

--- a/test/actions/render.spec.ts
+++ b/test/actions/render.spec.ts
@@ -17,10 +17,10 @@ describe("render()", () => {
             {
                 outputType: "png",
                 puppeteerOptions: {
-                    executablePath: "non/existing/path/to/chromium"
-                }
+                    executablePath: "non/existing/path/to/chromium",
+                },
             } as INormalizedOptions,
-        ).should.be.rejected.and.notify(pDone)
+        ).should.be.rejected.and.notify(pDone);
     });
 
     it("coughs up something when passed an ast asked to output svg", (pDone) => {

--- a/test/actions/render.spec.ts
+++ b/test/actions/render.spec.ts
@@ -6,13 +6,25 @@ import { INormalizedOptions } from "../../src/types";
 use(chaiAsPromised);
 
 // tslint:disable-next-line: no-var-requires
-const lAST = JSON.stringify(require("./fixtures/simplest.json"));
+const lAST = require("./fixtures/simplest.json");
 
 should();
 
 describe("render()", () => {
+    it("should fail when passed a non-executable executablePath", (pDone) => {
+        render.renderWithChromeHeadless(
+            lAST,
+            {
+                outputType: "png",
+                puppeteerOptions: {
+                    executablePath: "non/existing/path/to/chromium"
+                }
+            } as INormalizedOptions,
+        ).should.be.rejected.and.notify(pDone)
+    });
+
     it("coughs up something when passed an ast asked to output svg", (pDone) => {
-        render.renderTheShizzle(
+        render.renderWithChromeHeadless(
             lAST,
             {
                 outputType: "svg",
@@ -21,7 +33,7 @@ describe("render()", () => {
     });
 
     it("coughs something when passed an ast asked to output png", (pDone) => {
-        render.renderTheShizzle(
+        render.renderWithChromeHeadless(
             lAST,
             {
                 outputType: "png",

--- a/test/actions/render.spec.ts
+++ b/test/actions/render.spec.ts
@@ -28,6 +28,9 @@ describe("render()", () => {
             lAST,
             {
                 outputType: "svg",
+                puppeteerOptions: {
+                    args: ["--no-sandbox"], // ci server's docker/ linux does not support sandboxing yet
+                },
             } as INormalizedOptions,
         ).should.be.fulfilled.and.notify(pDone);
     });
@@ -37,6 +40,9 @@ describe("render()", () => {
             lAST,
             {
                 outputType: "png",
+                puppeteerOptions: {
+                    args: ["--no-sandbox"], // ci server's docker/ linux does not support sandboxing yet
+                },
             } as INormalizedOptions,
         ).should.be.fulfilled.and.notify(pDone);
     });


### PR DESCRIPTION
## Description
If puppeteer/ chrome headless fails, currently mscgenjs-cli returns the unhelpful `Invalid non-string/buffer chunk` error message instead of the root cause of the error. With this PR mscgenjs-cli will report the root cause of the error.

## Motivation and Context
Not explicitly raised in #21 - but people less tech savvy than the reporter would've been thoroughly befuddled by the generic error message instead of the loud & clear puppeteer message
```
Failed to launch chrome! spawn /usr/iznogood/bin/chromium ENOENT


TROUBLESHOOTING: https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md
```

## How Has This Been Tested?
Unit & manual tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- ~~~[ ] New feature (non-breaking change which adds functionality)~~~
- ~~~[ ] Breaking change (fix or feature that would cause existing functionality to change)~~~

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code I add will be subject to [The GNU General Public License v3](../LICENSE.md) ([text](../COPYING)), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- ~~~[ ] My change requires a change to the documentation.~~~
- ~~~[ ] I have updated the documentation accordingly.~~~
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.